### PR TITLE
Trigger dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,17 +10,17 @@ registries:
     url: https://npm.pkg.github.com
     token: ${{secrets.PACKAGE_TOKEN}}
 updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    open-pull-requests-limit: 15
+    rebase-strategy: 'disabled'
+    schedule:
+      interval: 'weekly'
   - package-ecosystem: 'npm'
     directory: '/'
     open-pull-requests-limit: 15
     rebase-strategy: 'disabled'
     registries:
       - npm-github
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Dependabot doesn't run automatically after the import, let's trigger it again.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
