### PR TITLE
Set document language to improve accessibility

### DIFF
--- a/.changeset/large-lions-flash.md
+++ b/.changeset/large-lions-flash.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-poll-widget': patch
+---
+
+Set document language to improve accessibility.

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,6 +22,7 @@ import i18n from 'i18next';
 import ChainedBackend from 'i18next-chained-backend';
 import HttpBackend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
+import { setLocale } from './lib/locale';
 
 i18n
   .use(ChainedBackend)
@@ -40,5 +41,11 @@ i18n
     supportedLngs: ['en', 'de'],
     nonExplicitSupportedLngs: true,
   });
+
+setLocale(i18n.language);
+
+i18n.on('languageChanged', () => {
+  setLocale(i18n.language);
+});
 
 export default i18n;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,8 +16,6 @@
 
 import { WidgetApiImpl } from '@matrix-widget-toolkit/api';
 import { getEnvironment, getNonce } from '@matrix-widget-toolkit/mui';
-import i18next from 'i18next';
-import { Settings } from 'luxon';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -39,12 +37,6 @@ if (version) {
     `You are running version "${version}" of the matrix-poll-widget!`
   );
 }
-
-Settings.defaultLocale = i18next.language;
-
-i18next.on('languageChanged', () => {
-  Settings.defaultLocale = i18next.language;
-});
 
 const widgetApiPromise = WidgetApiImpl.create({
   capabilities: widgetCapabilities,

--- a/src/lib/locale.test.ts
+++ b/src/lib/locale.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Settings } from 'luxon';
+import { setLocale } from './locale';
+
+describe('setLocale', () => {
+  it('should set luxon locale', () => {
+    setLocale('de');
+
+    expect(Settings.defaultLocale).toEqual('de');
+  });
+
+  it('should set HTML lang', () => {
+    setLocale('de');
+
+    expect(document.documentElement.lang).toEqual('de');
+  });
+});

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Settings } from 'luxon';
+
+export function setLocale(locale: string): void {
+  Settings.defaultLocale = locale;
+  document.documentElement.lang = locale;
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -23,6 +23,7 @@ import { toHaveNoViolations } from 'jest-axe';
 import { Settings } from 'luxon';
 // Make sure to initialize i18n (see mock below)
 import './i18n';
+import { setLocale } from './lib/locale';
 
 // Use a different configuration for i18next during tests
 jest.mock('./i18n', () => {
@@ -70,7 +71,8 @@ window.URL.revokeObjectURL = jest.fn();
 // We want our tests to be in a reproducible time zone, always resulting in
 // the same results, independent from where they are run.
 Settings.defaultZone = 'UTC';
-Settings.defaultLocale = 'en';
+
+setLocale('en');
 
 // Add support for jest-axe
 expect.extend(toHaveNoViolations);


### PR DESCRIPTION
Set the document language on locale changes, this guides screen readers to use the correct language when pronouncing things.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
