### PR TITLE
Reduce PR noise by allowing rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,18 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
+    rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'npm'
     directory: '/'
     open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
+    rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'docker'
     directory: '/'
     open-pull-requests-limit: 15
-    rebase-strategy: 'disabled'
+    rebase-strategy: 'auto'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Allows rebases which should reduce PRs getting recreated when the version is bumped further