### PR TITLE
Update build and push output type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,6 @@ jobs:
       - name: Build and push
         id: build_and_push
         uses: docker/build-push-action@v6
-        env:
-          DOCKER_IMAGE: ghcr.io/nordeck/matrix-poll-widget
         with:
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && secrets.GH_APP_OS_APP_ID != '' }}
           context: .
@@ -93,7 +91,6 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x
           sbom: true
           provenance: true
-          outputs: 'type=image'
 
       - name: Run Trivy to get an SBOM report of the container
         if: ${{ success() && steps.build_and_push.outputs.digest }}
@@ -131,6 +128,7 @@ jobs:
           publish: yarn changeset tag
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
   helm-lint-test:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
So that PRs from dependabot don't output an image and can skip the SBOM step.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
